### PR TITLE
Remove several errors reported by Tenon.io concerning images, …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ $RECYCLE.BIN/
 # OSX
 .DS_Store
 /public
+
+# vim
+*.swp
+*.*~

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -166,7 +166,10 @@
             <div class="single-fet">
               <div>
                 <a href="/desktop">
-                  <button type="button" class="btn btn-circle btn-xl flavour-desktop"><i class="fa fa-desktop fa-3x"></i></button>
+                  <button type="button" class="btn btn-circle btn-xl flavour-desktop">
+                      <span class="fa fa-desktop fa-3x"></span>
+                      <span class="sr-only">Desktop Icon</span>
+                  </button>
                 </a>
               </div>
               <h2><a href="/desktop">Desktop</a></h2>
@@ -177,7 +180,10 @@
             <div class="single-fet">
               <div>
                 <a href="/server">
-                  <button type="button" class="btn btn-circle btn-xl flavour-server"><i class="fa fa-server fa-3x"></i></button>
+                  <button type="button" class="btn btn-circle btn-xl flavour-server">
+                      <span class="fa fa-server fa-3x"></span>
+                      <span class="sr-only">Server Icon</span>
+                  </button>
                 </a>
               </div>
               <h2><a href="/server">Server</a></h2>
@@ -195,7 +201,10 @@
             <div class="single-fet">
               <div>
                 <a href="/cloud">
-                  <button type="button" class="btn btn-circle btn-xl flavour-cloud"><i class="fa fa-cloud fa-3x"></i></button>
+                  <button type="button" class="btn btn-circle btn-xl flavour-cloud">
+                      <span class="fa fa-cloud fa-3x"></span>
+                      <span class="sr-only">Cloud Icon</span>
+                  </button>
                 </a>
               </div>
               <h2><a href="/cloud">Cloud</a> </h2>
@@ -206,11 +215,20 @@
             <div class="single-fet">
               <div>
                 <a href="http://dl.sabayon.org/iso/daily/daily.html">
-                  <button type="button" class="btn btn-circle btn-xl flavour-testing"><i class="fa fa-flask fa-3x"></i></button>
+                  <button type="button" class="btn btn-circle btn-xl flavour-testing">
+                      <span class="fa fa-flask fa-3x"></span>
+                      <span class="sr-only">Flask Icon</span>
+                  </button>
                 </a>
               </div>
-              <h2><a href="http://dl.sabayon.org/iso/daily/daily.html">Testing</a> </h2>
-              <p class="italic">Help find them Bugs <a class="btn btn-xs btn-danger" href="https://bugs.sabayon.org/"><i class="fa fa-bug"></i></a></p>
+              <h2><a href="http://dl.sabayon.org/iso/daily/daily.html">Testing</a></h2>
+              <p class="italic">
+                Help find them Bugs
+                <a class="btn btn-xs btn-danger" href="https://bugs.sabayon.org/">
+                    <span class="fa fa-bug"></span>
+                    <span class="sr-only">Bug Icon</span>
+                </a>
+              </p>
             </div><!-- .single-fet -->
           </div><!-- .col-lg-6.text-center -->
         </div><!-- .row.features -->
@@ -227,7 +245,7 @@
 
     <div class="container">
       <div class="row">
-        <p>
+        <div>
           <h3 class="text-center" style="margin-top:116.2332px;">
             Sabayon is developed with <i class="fa fa-heart" style="color:#FF4E50"></i> from people all around the world that works together.
           </h3>
@@ -237,7 +255,7 @@
           <div class="text-center h3" style="margin-top:57.2px;margin-bottom:139.1667px">
             If you want to contribute, <a href="https://github.com/Sabayon/"> our code is hosted on GitHub</a>.
           </div><!-- .text-center.h3 -->
-        </p>
+        </div>
       </div><!-- .row -->
     </div><!-- .container -->
   </div><!-- .community -->
@@ -251,7 +269,7 @@
 
     <div class="container">
       <div class="row">
-        <p>
+        <div>
           <h3 class="text-center" style="margin-top:130px;margin-bottom:21.4333px;">
             Check the <a href="/latest">Release Notes</a> for the version you are downloading.
           </h3>
@@ -261,7 +279,7 @@
           <div class="text-center h3" style="margin-bottom:85px;">
             If you feel lost after install, take a minute to read the <a href="https://wiki.sabayon.org/index.php?title=En:Entropy#Fresh_Install_-_What_to_do.3F" class="italic">"Fresh install, what now?"</a> guide to familiarize with our package manager.
           </div>
-        </p>
+        </div>
       </div><!-- .row -->
     </div><!-- .container -->
   </div><!-- .documentation -->

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,31 +1,32 @@
-<nav class="navbar navbar-default navbar-fixed-top" role="navigation">
+<nav class="navbar navbar-default navbar-fixed-top">
     <div class="container">
         <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-ex1-collapse">
-            <span class="sr-only">Toggle Navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            </button>
-            <a class="navbar-brand" href="{{ .Site.BaseURL }}"><img src="/img/navbar_sabayon_logo_trans.png" class="img-responsive"></a>
-        </div>
+            <button type="button" class="navbar-toggle" data-toggle="collapse"
+                    data-target=".navbar-ex1-collapse">
+                <span class="sr-only">Toggle Navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+            </button><!-- .navbar-toggle -->
+            <a class="navbar-brand" href="{{ .Site.BaseURL }}">
+                <img src="/img/navbar_sabayon_logo_trans.png"
+                     alt="Sabayon Logo" width="135" height="35"
+                     class="img-responsive" />
+                <span class="sr-only">Sabayon Linux</span>
+            </a><!-- .navbar-brand -->
+        </div><!-- .navbar-header -->
 
         <div class="collapse navbar-collapse navbar-ex1-collapse">
             <ul class="nav navbar-nav pull-right">
-
-				    <li><a href="https://forum.sabayon.org/">Forum</a></li>
-                                    <li><a href="/chat/">Support</a></li>
-                                    <li><a href="https://wiki.sabayon.org/">Wiki</a></li>
-                                    <li><a href="/download"> Download</a></li>
-
-                                    <li><a href="https://bugs.sabayon.org/"> Bugs</a></li>
-                                    <li><a href="https://packages.sabayon.org/">Packages</a></li>
-                                    <li><a href="https://sabayon.github.io/community-website/">SCR</a></li>
-				    <li><a href="/blog/"> Blog</a></li>
-            </ul>
-
-
-        </div>
-
-    </div>
-</nav>
+                <li><a href="https://forum.sabayon.org/">Forum</a></li>
+                <li><a href="/chat/">Support</a></li>
+                <li><a href="https://wiki.sabayon.org/">Wiki</a></li>
+                <li><a href="/download"> Download</a></li>
+                <li><a href="https://bugs.sabayon.org/"> Bugs</a></li>
+                <li><a href="https://packages.sabayon.org/">Packages</a></li>
+                <li><a href="https://sabayon.github.io/community-website/">SCR</a></li>
+                <li><a href="/blog/"> Blog</a></li>
+            </ul><!-- .nav.navbar-nav.pull-right -->
+        </div><!-- .collapse.navbar-collapse.navbar-ex1-collapse -->
+    </div><!-- .container -->
+</nav><!-- .navbar.navbar-default.navbar-fixed-top -->


### PR DESCRIPTION
…paragraphs and Font Awesome Icons.

Personally I find `<i>` bad for FA icons. I know they shall be re-interpreted as "icon tag" in HTML5, but they were connotated as "italic" in HTML4 and I care for backwards compability ;-)

Usually you would provide an `alt`-attribute to images, but that is not possible with them. Moreover until the Font Awesome font is downloaded and parsed the icons look ugly.

Paragraphs must not contain block elements.
