### PR TITLE
Update headline.html: minor grammatical fix

### DIFF
--- a/layouts/partials/headline.html
+++ b/layouts/partials/headline.html
@@ -10,7 +10,7 @@
     </a>
   </div><!-- .headline -->
   <p class="why-sabayon">
-    Sabayon is a beginner-friendly Gentoo-based Open Source Linux distribution. We aim to deliver the best "out of the box" user experience by providing the latest open source technologies in an elegant format. In Sabayon everything should just
+    Sabayon is a beginner-friendly Gentoo-based open-source Linux distribution. We aim to deliver the best "out of the box" user experience by providing the latest open source technologies in an elegant format. In Sabayon everything should just
     work. We offer a bleeding edge operating system that is both stable and reliable.
   </p>
 </div><!-- #home.headline-container -->


### PR DESCRIPTION
Hi,

In this change I changed Open Source to open-source. Open Source shouldn't be capitalized &mdash; it is an adjective, not a proper noun (and only proper nouns should be capitalized mid-way through a sentence). Open source should also ideally be hyphenated.

Thanks for your time,
Brenton